### PR TITLE
Build Cache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   push:
-      
+
   pull_request:
     branches: [ "main" ]
 
@@ -19,15 +19,30 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-        contents: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+          restore-keys: |
+            ${{runner.os}}-${{runner.arch}}-build-cache-
+
       - name: build
         run: cargo build --verbose --target x86_64-unknown-linux-gnu --release
 
+      - name: Cache Build Output
+        uses: actions/cache/save@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+
       - name: Update indev release
+        if: github.ref_name == 'main'
         run: gh release upload indev ./target/x86_64-unknown-linux-gnu/release/numake --clobber
 
       - name: Upload artifact
@@ -44,8 +59,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+          restore-keys: |
+            ${{runner.os}}-${{runner.arch}}-build-cache-
+
       - name: build
         run: cargo build --verbose --target x86_64-unknown-linux-gnu
+
+      - name: Cache Build Output
+        uses: actions/cache/save@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -59,20 +88,35 @@ jobs:
     runs-on: windows-latest
 
     permissions:
-        contents: write
+      contents: write
     
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install toolchain
         run: rustup target add x86_64-pc-windows-gnu
-    
+
+      - name: Restore build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+          restore-keys: |
+            ${{runner.os}}-${{runner.arch}}-build-cache-
+
       - name: build
         run: cargo build --verbose --target x86_64-pc-windows-gnu --release
 
+      - name: Cache Build Output
+        uses: actions/cache/save@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+
       - name: Update indev release
+        if: github.ref_name == 'main'
         run: gh release upload indev ./target/x86_64-pc-windows-gnu/release/numake.exe --clobber
-        
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -88,10 +132,24 @@ jobs:
 
       - name: Install toolchain
         run: rustup target add x86_64-pc-windows-gnu
-    
+
+      - name: Restore build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+          restore-keys: |
+            ${{runner.os}}-${{runner.arch}}-build-cache-
+
       - name: build
         run: cargo build --verbose --target x86_64-pc-windows-gnu
-        
+
+      - name: Cache Build Output
+        uses: actions/cache/save@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -109,8 +167,22 @@ jobs:
       - name: Install toolchain
         run: rustup target add x86_64-pc-windows-msvc
 
+      - name: Restore build cache
+        uses: actions/cache/restore@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
+          restore-keys: |
+            ${{runner.os}}-${{runner.arch}}-build-cache-
+
       - name: build
         run: cargo build --verbose --target x86_64-pc-windows-msvc
+
+      - name: Cache Build Output
+        uses: actions/cache/save@v4
+        with:
+          path: 'target'
+          key: ${{runner.os}}-${{runner.arch}}-build-cache-${{hashFiles('target/')}}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "main" ]
       
   pull_request:
     branches: [ "main" ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -168,26 +168,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
 
 [[package]]
 name = "bzip2"
@@ -197,6 +181,15 @@ checksum = "bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58"
 dependencies = [
  "bzip2-sys",
  "libc",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
+dependencies = [
+    "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -239,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -249,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -261,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -276,15 +269,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cmake"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -303,6 +287,19 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+    "encode_unicode",
+    "libc",
+    "once_cell",
+    "unicode-width",
+    "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -337,21 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,12 +341,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -408,7 +384,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+    "console 0.15.10",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -488,12 +464,12 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
+    "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -595,7 +571,21 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+    "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+    "cfg-if",
+    "js-sys",
+    "libc",
+    "r-efi",
+    "wasi 0.14.2+wasi-0.2.4",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -926,7 +916,7 @@ version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
 dependencies = [
- "console",
+    "console 0.15.10",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
@@ -971,13 +961,19 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775bf80d5878ab7c2b1080b5351a48b2f737d9f6f8b383574eebcc22be0dfccb"
 
 [[package]]
 name = "libc"
@@ -992,17 +988,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.20"
+name = "liblzma"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0f7295a34685977acb2e8cc8b08ee4a8dffd6cf278eeccddbe1ed55ba815d5"
+checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
 dependencies = [
- "cmake",
+    "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+    "cc",
  "libc",
+    "pkg-config",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+    "zlib-rs",
 ]
 
 [[package]]
@@ -1010,6 +1025,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1068,16 +1089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
-dependencies = [
- "byteorder",
- "crc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,9 +1102,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1105,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+    "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1177,9 +1188,9 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64",
- "bzip2 0.5.0",
+    "bzip2 0.6.0",
  "clap",
- "console",
+    "console 0.16.0",
  "dialoguer",
  "dunce",
  "encoding_rs",
@@ -1193,7 +1204,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 2.0.9",
+    "thiserror 2.0.12",
  "toml",
  "zip",
 ]
@@ -1283,7 +1294,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1339,15 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,34 +1368,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -1457,7 +1435,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+    "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1485,7 +1463,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+    "linux-raw-sys 0.4.14",
+    "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+    "bitflags",
+    "errno",
+    "libc",
+    "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1600,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1612,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1729,15 +1720,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1806,15 +1797,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom",
+    "getrandom 0.3.3",
  "once_cell",
- "rustix",
+    "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -1829,11 +1819,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.9",
+    "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1849,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1937,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1949,25 +1939,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+    "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2102,21 +2099,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+    "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+    "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -2128,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2141,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2151,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2164,15 +2171,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+    "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2196,7 +2206,7 @@ checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
- "rustix",
+    "rustix 0.38.42",
  "winsafe",
 ]
 
@@ -2208,7 +2218,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2217,7 +2227,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2227,7 +2237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2236,7 +2246,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2245,7 +2255,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+    "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+    "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2254,14 +2273,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+    "windows_aarch64_gnullvm 0.52.6",
+    "windows_aarch64_msvc 0.52.6",
+    "windows_i686_gnu 0.52.6",
+    "windows_i686_gnullvm 0.52.6",
+    "windows_i686_msvc 0.52.6",
+    "windows_x86_64_gnu 0.52.6",
+    "windows_x86_64_gnullvm 0.52.6",
+    "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+    "windows_aarch64_gnullvm 0.53.0",
+    "windows_aarch64_msvc 0.53.0",
+    "windows_i686_gnu 0.53.0",
+    "windows_i686_gnullvm 0.53.0",
+    "windows_i686_msvc 0.53.0",
+    "windows_x86_64_gnu 0.53.0",
+    "windows_x86_64_gnullvm 0.53.0",
+    "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2271,10 +2306,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2283,10 +2330,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2295,10 +2354,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2307,16 +2378,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.22"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -2326,6 +2409,15 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+    "bitflags",
+]
 
 [[package]]
 name = "write16"
@@ -2361,27 +2453,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2449,32 +2520,35 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
 dependencies = [
  "aes",
  "arbitrary",
- "bzip2 0.4.4",
+    "bzip2 0.5.0",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
  "deflate64",
- "displaydoc",
  "flate2",
+    "getrandom 0.3.3",
  "hmac",
  "indexmap",
- "lzma-rs",
+    "liblzma",
  "memchr",
  "pbkdf2",
- "rand",
  "sha1",
- "thiserror 2.0.9",
  "time",
  "zeroize",
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
-    "libbz2-rs-sys",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -295,11 +295,11 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
 dependencies = [
-    "encode_unicode",
-    "libc",
-    "once_cell",
-    "unicode-width",
-    "windows-sys 0.60.2",
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -384,7 +384,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
-    "console 0.15.10",
+ "console 0.15.10",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -469,7 +469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
-    "libz-rs-sys",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -571,7 +571,7 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
-    "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -580,12 +580,12 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
-    "cfg-if",
-    "js-sys",
-    "libc",
-    "r-efi",
-    "wasi 0.14.2+wasi-0.2.4",
-    "wasm-bindgen",
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -916,7 +916,7 @@ version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
 dependencies = [
-    "console 0.15.10",
+ "console 0.15.10",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
@@ -988,7 +988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -997,7 +997,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
 dependencies = [
-    "liblzma-sys",
+ "liblzma-sys",
 ]
 
 [[package]]
@@ -1006,9 +1006,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
 dependencies = [
-    "cc",
+ "cc",
  "libc",
-    "pkg-config",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1017,7 +1017,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
 dependencies = [
-    "zlib-rs",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
-    "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1188,9 +1188,9 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64",
-    "bzip2 0.6.0",
+ "bzip2 0.6.0",
  "clap",
-    "console 0.16.0",
+ "console 0.16.0",
  "dialoguer",
  "dunce",
  "encoding_rs",
@@ -1204,7 +1204,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
-    "thiserror 2.0.12",
+ "thiserror 2.0.12",
  "toml",
  "zip",
 ]
@@ -1294,7 +1294,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1435,7 +1435,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
-    "getrandom 0.2.15",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1463,8 +1463,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
-    "linux-raw-sys 0.4.14",
-    "windows-sys 0.59.0",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1473,10 +1473,10 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
-    "bitflags",
-    "errno",
-    "libc",
-    "linux-raw-sys 0.9.4",
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1802,9 +1802,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
-    "getrandom 0.3.3",
+ "getrandom 0.3.3",
  "once_cell",
-    "rustix 1.0.7",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -1823,7 +1823,7 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
-    "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1956,7 +1956,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
-    "toml_write",
+ "toml_write",
  "winnow",
 ]
 
@@ -2104,7 +2104,7 @@ version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
-    "wit-bindgen-rt",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
-    "rustversion",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -2175,7 +2175,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
-    "unicode-ident",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2206,7 +2206,7 @@ checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
-    "rustix 0.38.42",
+ "rustix 0.38.42",
  "winsafe",
 ]
 
@@ -2218,7 +2218,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2227,7 +2227,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2237,7 +2237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2246,7 +2246,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2255,7 +2255,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
-    "windows-targets 0.52.6",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2264,7 +2264,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
-    "windows-targets 0.53.2",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2273,14 +2273,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
-    "windows_aarch64_gnullvm 0.52.6",
-    "windows_aarch64_msvc 0.52.6",
-    "windows_i686_gnu 0.52.6",
-    "windows_i686_gnullvm 0.52.6",
-    "windows_i686_msvc 0.52.6",
-    "windows_x86_64_gnu 0.52.6",
-    "windows_x86_64_gnullvm 0.52.6",
-    "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2289,14 +2289,14 @@ version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
-    "windows_aarch64_gnullvm 0.53.0",
-    "windows_aarch64_msvc 0.53.0",
-    "windows_i686_gnu 0.53.0",
-    "windows_i686_gnullvm 0.53.0",
-    "windows_i686_msvc 0.53.0",
-    "windows_x86_64_gnu 0.53.0",
-    "windows_x86_64_gnullvm 0.53.0",
-    "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2416,7 +2416,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
-    "bitflags",
+ "bitflags",
 ]
 
 [[package]]
@@ -2526,15 +2526,15 @@ checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
 dependencies = [
  "aes",
  "arbitrary",
-    "bzip2 0.5.0",
+ "bzip2 0.5.0",
  "constant_time_eq",
  "crc32fast",
  "deflate64",
  "flate2",
-    "getrandom 0.3.3",
+ "getrandom 0.3.3",
  "hmac",
  "indexmap",
-    "liblzma",
+ "liblzma",
  "memchr",
  "pbkdf2",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.95" }
 base64 = "0.22.1"
-bzip2 = "0.5.0"
-clap = { version = "4.5.23", features = ["derive"] }
-console = "0.15.10"
+bzip2 = "0.6.0"
+clap = { version = "4.5.40", features = ["derive"] }
+console = "0.16.0"
 dialoguer = "0.11.0"
 dunce = { version = "1.0.5" }
 encoding_rs = "0.8.34"
@@ -19,15 +19,14 @@ mlua = { version = "0.10.2", features = ["vendored", "anyhow", "luau-jit", "user
 pathdiff = { version = "0.2.3" }
 reqwest = { version = "0.12.12", features = ["blocking"] }
 serde = { version = "1.0.217", features = ["derive"] }
-serde_json = { version = "1.0.135" }
+serde_json = { version = "1.0.140" }
 sha256 = "1.5.0"
-strum = "0.26.3"
-strum_macros = "0.26.4"
-tempfile = { version = "3.15.0" }
-thiserror = "2.0.9"
-toml = { version = "0.8.19" }
-zip = { version = "2.2.2", features = [
-    "deflate-zlib-ng",
+strum = "0.27.1"
+strum_macros = "0.27.1"
+tempfile = { version = "3.20.0" }
+thiserror = "2.0.12"
+toml = { version = "0.8.23" }
+zip = { version = "4.2.0", features = [
     "deflate-zopfli",
     "zstd",
     "lzma",

--- a/src/lib/compilers/mingw.rs
+++ b/src/lib/compilers/mingw.rs
@@ -1,35 +1,54 @@
 use std::{
+	collections::{
+		HashMap,
+		HashSet,
+	},
 	fs,
 	path::PathBuf,
 	process::Command,
 };
-use std::collections::{HashMap, HashSet};
-use crate::lib::data::environment::Environment;
-use crate::lib::data::project::Project;
-use crate::lib::data::project_language::ProjectLanguage;
-use crate::lib::data::project_type::ProjectType;
-use crate::lib::data::source_file_type::SourceFileType;
-use crate::lib::runtime::system::System;
-use crate::lib::ui::UI;
-use mlua::{prelude::LuaValue, FromLua, Lua, UserData, UserDataMethods, Value};
+
+use mlua::{
+	prelude::LuaValue,
+	FromLua,
+	Lua,
+	UserData,
+	UserDataMethods,
+	Value,
+};
 use pathdiff::diff_paths;
-use crate::lib::util::cache::Cache;
+
+use crate::lib::{
+	data::{
+		environment::Environment,
+		project::Project,
+		project_language::ProjectLanguage,
+		project_type::ProjectType,
+		source_file_type::SourceFileType,
+	},
+	runtime::system::System,
+	ui::UI,
+	util::cache::Cache,
+};
 
 #[derive(Clone)]
-pub struct MinGW {
+pub struct MinGW
+{
 	environment: Environment,
 	cache: Cache,
 	ui: UI,
 	system: System,
 }
 
-impl MinGW {
+impl MinGW
+{
 	pub fn new(
 		environment: Environment,
 		cache: Cache,
 		ui: UI,
 		system: System,
-	) -> Self {
+	) -> Self
+	{
 		MinGW {
 			environment,
 			cache,
@@ -44,7 +63,8 @@ impl MinGW {
 		obj_dir: &PathBuf,
 		mingw: &String,
 		o_files: &mut Vec<String>,
-	) -> anyhow::Result<()> {
+	) -> anyhow::Result<()>
+	{
 		let source_files = project.source_files.get(&SourceFileType::Code);
 
 		let binding = self
@@ -66,44 +86,50 @@ impl MinGW {
 			.collect::<HashSet<String>>();
 
 		/*
-         * Hash the contents of every source file once
-         * so we don't have to do it multiple times.
-         */
+		 * Hash the contents of every source file once
+		 * so we don't have to do it multiple times.
+		 */
 		let hashes: HashMap<&PathBuf, String> = source_files
 			.iter()
-			.filter_map(|file| match sha256::try_digest(file) {
-				Ok(digest) => Some((file, digest)),
-				Err(_) => None,
+			.filter_map(|file| {
+				match sha256::try_digest(file) {
+					Ok(digest) => Some((file, digest)),
+					Err(_) => None,
+				}
 			})
 			.collect();
 
 		let dirty_files: Vec<&PathBuf> = source_files
 			.iter()
-			.filter(|file| match hashes.get(file) {
-				Some(hash) => {
-					!mingw_cache.contains(hash)
-				}
+			.filter(|file| {
+				match hashes.get(file) {
+					Some(hash) => !mingw_cache.contains(hash),
 
-				None => true,
+					None => true,
+				}
 			})
 			.collect();
 
 		let clean_hashes: HashSet<String> = source_files
 			.iter()
-			.filter_map(|file| match hashes.get(file) {
-				Some(hash) => {
-					if mingw_cache.contains(hash) {
-						Some(hash.clone())
-					} else {
-						None
+			.filter_map(|file| {
+				match hashes.get(file) {
+					Some(hash) => {
+						if mingw_cache.contains(hash) {
+							Some(hash.clone())
+						} else {
+							None
+						}
 					}
-				}
 
-				None => None,
+					None => None,
+				}
 			})
 			.collect();
 
-		let progress = self.ui.create_bar(dirty_files.len() as u64, "Compiling... ");
+		let progress = self
+			.ui
+			.create_bar(dirty_files.len() as u64, "Compiling... ");
 
 		mingw_cache = clean_hashes;
 
@@ -116,6 +142,10 @@ impl MinGW {
 					.unwrap()
 					.to_string() + ".o",
 			);
+
+			if !o_file.parent().unwrap().exists() {
+				fs::create_dir_all(o_file.parent().unwrap())?;
+			}
 
 			o_files.push(o_file.to_str().unwrap().to_string());
 
@@ -135,18 +165,10 @@ impl MinGW {
 					},
 			);
 
-
-
-			if !o_file.parent().unwrap().exists() {
-				fs::create_dir_all(o_file.parent().unwrap())?;
-			}
-
 			let mut compiler_args = vec![
 				"-c".to_string(),
 				format!("-o{}", o_file.to_str().unwrap()),
 			];
-
-
 
 			for incl in project.include_paths.clone() {
 				compiler_args.push(format!("-I{incl}"))
@@ -172,7 +194,7 @@ impl MinGW {
 					Ok(status)
 				}
 
-				Err(err) => Err(err)
+				Err(err) => Err(err),
 			}?;
 		}
 
@@ -197,10 +219,13 @@ impl MinGW {
 		mingw: &String,
 		res_dir: &PathBuf,
 		o_files: &mut Vec<String>,
-	) -> anyhow::Result<()> {
+	) -> anyhow::Result<()>
+	{
 		let resource_files =
 			project.source_files.get(&SourceFileType::Resource);
-		let progress = self.ui.create_bar(resource_files.len() as u64, "Compiling Resources... ");
+		let progress = self
+			.ui
+			.create_bar(resource_files.len() as u64, "Compiling Resources... ");
 		// RESOURCE FILE HANDLING
 		for resource_file in resource_files {
 			progress.inc(1);
@@ -263,7 +288,8 @@ impl MinGW {
 		mingw: &String,
 		output: &String,
 		o_files: &mut Vec<String>,
-	) -> anyhow::Result<()> {
+	) -> anyhow::Result<()>
+	{
 		let spinner = self.ui.create_spinner("Linking...");
 		match project.project_type {
 			ProjectType::StaticLibrary => {
@@ -348,7 +374,8 @@ impl MinGW {
 	fn build(
 		&mut self,
 		project: &Project,
-	) -> anyhow::Result<()> {
+	) -> anyhow::Result<()>
+	{
 		let obj_dir: PathBuf = (self.environment)
 			.numake_directory
 			.join(format!("obj/{}", &project.name));
@@ -395,22 +422,26 @@ impl MinGW {
 	}
 }
 
-impl UserData for MinGW {
-	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
-		methods.add_method_mut("build", |_, this, project: Project| match this
-			.build(&project)
-		{
-			Ok(_) => Ok(()),
-			Err(err) => Err(mlua::Error::external(err)),
+impl UserData for MinGW
+{
+	fn add_methods<M: UserDataMethods<Self>>(methods: &mut M)
+	{
+		methods.add_method_mut("build", |_, this, project: Project| {
+			match this.build(&project) {
+				Ok(_) => Ok(()),
+				Err(err) => Err(mlua::Error::external(err)),
+			}
 		})
 	}
 }
 
-impl FromLua for MinGW {
+impl FromLua for MinGW
+{
 	fn from_lua(
 		value: LuaValue,
 		_: &Lua,
-	) -> mlua::Result<Self> {
+	) -> mlua::Result<Self>
+	{
 		match value {
 			Value::UserData(user_data) => {
 				if user_data.is::<Self>() {

--- a/src/lib/compilers/msvc.rs
+++ b/src/lib/compilers/msvc.rs
@@ -264,6 +264,7 @@ impl MSVC {
 		);
 
 		self.cache.set_value("msvc_cache", msvc_cache_toml)?;
+		self.cache.flush()?;
 		Ok(())
 	}
 

--- a/src/lib/compilers/msvc.rs
+++ b/src/lib/compilers/msvc.rs
@@ -38,6 +38,7 @@ use crate::lib::{
 		error::NuMakeError::VcNotFound,
 	},
 };
+use crate::lib::util::error::NuMakeError::MsvcWindowsOnly;
 
 #[derive(Clone)]
 pub struct MSVC

--- a/src/lib/runtime/mod.rs
+++ b/src/lib/runtime/mod.rs
@@ -60,7 +60,7 @@ impl Runtime {
 			storage: Storage::new(cache.clone()),
 			filesystem: Filesystem::new(environment.clone()),
 			msvc: MSVC::new(environment.clone(), cache.clone(), ui.clone(), system.clone()),
-			mingw: MinGW::new(environment.clone(), ui.clone(), system.clone()),
+			mingw: MinGW::new(environment.clone(), cache.clone(), ui.clone(), system.clone()),
 			generic: Generic::new(
 				environment.clone(),
 				ui.clone(),

--- a/src/lib/runtime/mod.rs
+++ b/src/lib/runtime/mod.rs
@@ -1,20 +1,33 @@
-use crate::lib::compilers::generic::Generic;
-use crate::lib::compilers::mingw::MinGW;
-use crate::lib::compilers::msvc::MSVC;
-use crate::lib::compilers::{generic, mingw, msvc};
-use crate::lib::data::environment::Environment;
-use crate::lib::data::project::Project;
-use crate::lib::runtime::filesystem::Filesystem;
-use crate::lib::runtime::network::Network;
-use crate::lib::runtime::storage::Storage;
-use crate::lib::runtime::system::System;
-use crate::lib::runtime::task_manager::TaskManager;
-use crate::lib::ui::{format, UI};
-use crate::lib::util::cache::Cache;
-use anyhow::anyhow;
-use mlua::prelude::LuaResult;
-use mlua::{Compiler, Lua};
 use std::fs;
+
+use mlua::{
+	Compiler,
+	Lua,
+};
+
+use crate::lib::{
+	compilers::{
+		generic,
+		generic::Generic,
+		mingw,
+		mingw::MinGW,
+		msvc,
+		msvc::MSVC,
+	},
+	data::{
+		environment::Environment,
+		project::Project,
+	},
+	runtime::{
+		filesystem::Filesystem,
+		network::Network,
+		storage::Storage,
+		system::System,
+		task_manager::TaskManager,
+	},
+	ui::UI,
+	util::cache::Cache,
+};
 
 pub mod filesystem;
 pub mod network;
@@ -22,7 +35,8 @@ pub mod storage;
 pub mod system;
 pub mod task_manager;
 
-pub struct Runtime {
+pub struct Runtime
+{
 	// Tools
 	task_manager: task_manager::TaskManager,
 	network: network::Network,
@@ -42,11 +56,13 @@ pub struct Runtime {
 	lua: Lua,
 }
 
-impl Runtime {
+impl Runtime
+{
 	pub fn new(
-        ui: UI,
+		ui: UI,
 		environment: Environment,
-	) -> anyhow::Result<Self>{
+	) -> anyhow::Result<Self>
+	{
 		let cache: Cache = Cache::new(environment.clone())?;
 		let system = System::new(ui.clone());
 
@@ -59,10 +75,21 @@ impl Runtime {
 			),
 			storage: Storage::new(cache.clone()),
 			filesystem: Filesystem::new(environment.clone()),
-			msvc: MSVC::new(environment.clone(), cache.clone(), ui.clone(), system.clone()),
-			mingw: MinGW::new(environment.clone(), cache.clone(), ui.clone(), system.clone()),
+			msvc: MSVC::new(
+				environment.clone(),
+				cache.clone(),
+				ui.clone(),
+				system.clone(),
+			),
+			mingw: MinGW::new(
+				environment.clone(),
+				cache.clone(),
+				ui.clone(),
+				system.clone(),
+			),
 			generic: Generic::new(
 				environment.clone(),
+				cache.clone(),
 				ui.clone(),
 				system.clone(),
 			),
@@ -77,7 +104,8 @@ impl Runtime {
 	pub(crate) fn execute_script(
 		&mut self,
 		filename: &String,
-	) -> anyhow::Result<()> {
+	) -> anyhow::Result<()>
+	{
 		let file_size = fs::metadata(filename)?.len();
 		let mut should_compile = self.cache.get_value(filename)
 			!= Some(toml::Value::from(file_size.to_string()));
@@ -120,14 +148,13 @@ impl Runtime {
 		Ok(())
 	}
 
-	pub fn get_tasks(&mut self) -> Vec<String> {
-		self.task_manager.get_tasks()
-	}
+	pub fn get_tasks(&mut self) -> Vec<String> { self.task_manager.get_tasks() }
 
 	pub fn execute_task(
 		&mut self,
 		task: &str,
-	) -> anyhow::Result<()> {
-        self.task_manager.run(task)
+	) -> anyhow::Result<()>
+	{
+		self.task_manager.run(task)
 	}
 }

--- a/src/lib/runtime/mod.rs
+++ b/src/lib/runtime/mod.rs
@@ -59,7 +59,7 @@ impl Runtime {
 			),
 			storage: Storage::new(cache.clone()),
 			filesystem: Filesystem::new(environment.clone()),
-			msvc: MSVC::new(environment.clone(), ui.clone(), system.clone()),
+			msvc: MSVC::new(environment.clone(), cache.clone(), ui.clone(), system.clone()),
 			mingw: MinGW::new(environment.clone(), ui.clone(), system.clone()),
 			generic: Generic::new(
 				environment.clone(),

--- a/src/lib/util/cache.rs
+++ b/src/lib/util/cache.rs
@@ -93,7 +93,7 @@ impl Cache {
 
 	pub fn set_value(
 		&mut self,
-		key: &String,
+		key: &str,
 		val: toml::Value,
 	) -> anyhow::Result<()> {
 		(*self.toml.lock().unwrap()).insert(hash_string(key), val);
@@ -102,7 +102,7 @@ impl Cache {
 
 	pub fn get_value(
 		&mut self,
-		key: &String,
+		key: &str,
 	) -> Option<toml::Value> {
 		match (*self.toml.lock().unwrap()).get(&hash_string(key)) {
 			Some(v) => Some(v.clone()),

--- a/src/lib/util/mod.rs
+++ b/src/lib/util/mod.rs
@@ -17,7 +17,7 @@ use sha256::digest;
 pub mod cache;
 pub mod error;
 
-pub fn hash_string(val: &String) -> String {
+pub fn hash_string(val: &str) -> String {
     let mut result = digest(val);
     result.truncate(16);
 


### PR DESCRIPTION
* Instead of recompiling the entire source every time, we now keep track of file contents via hashes and only recompile files that have changed.
* Cache can be manually invalidated by simply deleting `numae/.cache` in the project directory