### PR TITLE
Refactor build cache to use binary serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +143,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitcode"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf300f4aa6e66f3bdff11f1236a88c622fe47ea814524792240b4d554d9858ee"
+dependencies = [
+ "arrayvec",
+ "bitcode_derive",
+ "bytemuck",
+ "glam",
+ "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +196,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "bytes"
@@ -593,6 +629,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glam"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a99dbe56b72736564cfa4b85bf9a33079f16ae8b74983ab06af3b1a3696b11"
 
 [[package]]
 name = "h2"
@@ -1188,6 +1230,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64",
+ "bitcode",
  "bzip2 0.6.0",
  "clap",
  "console 0.16.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.95" }
 base64 = "0.22.1"
+bitcode = "0.6.6"
 bzip2 = "0.6.0"
 clap = { version = "4.5.40", features = ["derive"] }
 console = "0.16.0"

--- a/src/lib/runtime/mod.rs
+++ b/src/lib/runtime/mod.rs
@@ -28,6 +28,7 @@ use crate::lib::{
 	ui::UI,
 	util::cache::Cache,
 };
+use crate::lib::util::build_cache::BuildCache;
 
 pub mod filesystem;
 pub mod network;
@@ -64,6 +65,7 @@ impl Runtime
 	) -> anyhow::Result<Self>
 	{
 		let cache: Cache = Cache::new(environment.clone())?;
+		let build_cache: BuildCache = BuildCache::new(environment.clone())?;
 		let system = System::new(ui.clone());
 
 		Ok(Runtime {
@@ -77,19 +79,19 @@ impl Runtime
 			filesystem: Filesystem::new(environment.clone()),
 			msvc: MSVC::new(
 				environment.clone(),
-				cache.clone(),
+				build_cache.clone(),
 				ui.clone(),
 				system.clone(),
 			),
 			mingw: MinGW::new(
 				environment.clone(),
-				cache.clone(),
+				build_cache.clone(),
 				ui.clone(),
 				system.clone(),
 			),
 			generic: Generic::new(
 				environment.clone(),
-				cache.clone(),
+				build_cache.clone(),
 				ui.clone(),
 				system.clone(),
 			),

--- a/src/lib/util/build_cache.rs
+++ b/src/lib/util/build_cache.rs
@@ -1,0 +1,51 @@
+use crate::lib::data::environment::Environment;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+#[derive(Default, Debug, Clone)]
+pub struct BuildCache {
+	directory: PathBuf,
+}
+
+impl BuildCache {
+	pub fn new(environment: Environment) -> anyhow::Result<Self> {
+		let directory = environment.numake_directory.join(".cache");
+		if !directory.exists() {
+			fs::create_dir_all(&directory)?;
+		}
+
+		Ok(BuildCache { directory })
+	}
+
+	pub fn write_set(
+		&self,
+		array_name: &str,
+		contents: HashSet<String>,
+	) -> anyhow::Result<()> {
+		let file_path = self.directory.join(array_name.to_string() + ".bcache");
+		let bytes = bitcode::encode(&contents);
+		fs::write(&file_path, bytes)?;
+		Ok(())
+	}
+
+	pub fn read_set(
+		&self,
+		array_name: &str,
+	) -> anyhow::Result<HashSet<String>> {
+		let file_path = self.directory.join(array_name.to_string() + ".bcache");
+        if !file_path.exists() {
+            return Ok(HashSet::default());
+        }
+        
+		match bitcode::decode::<HashSet<String>>(
+			fs::read(file_path)?.as_slice(),
+		) {
+            Ok(v) => Ok(v),
+            Err(_) => Ok(HashSet::default())
+        }
+	}
+}

--- a/src/lib/util/mod.rs
+++ b/src/lib/util/mod.rs
@@ -16,6 +16,7 @@ use sha256::digest;
 
 pub mod cache;
 pub mod error;
+pub mod build_cache;
 
 pub fn hash_string(val: &str) -> String {
     let mut result = digest(val);


### PR DESCRIPTION
Introduces a new BuildCache struct that stores build cache data using binary serialization via the bitcode crate, replacing the previous TOML-based Cache usage in compilers. Updates compilers and runtime to use BuildCache for improved performance and reliability. Adds bitcode and related dependencies to Cargo.toml.