### PR TITLE
Relative linker paths

### DIFF
--- a/src/lib/compilers/generic.rs
+++ b/src/lib/compilers/generic.rs
@@ -58,7 +58,7 @@ impl Generic
 		&mut self,
 		project: &Project,
 		toolset_compiler: &String,
-		obj_dir: &PathBuf,
+		obj_dir: &Path,
 		o_files: &mut Vec<String>,
 	) -> anyhow::Result<()>
 	{
@@ -114,7 +114,7 @@ impl Generic
 
 		for file in source_files.clone() {
 			let o_file = obj_dir.join(
-				diff_paths(&file, &(self.environment).project_directory)
+				diff_paths(&file, &self.environment.project_directory)
 					.unwrap()
 					.to_str()
 					.unwrap()
@@ -159,7 +159,7 @@ impl Generic
 			match self.system.execute(
 				compiler
 					.args(&compiler_args)
-					.current_dir(&(self.environment).project_directory),
+					.current_dir(&self.environment.project_directory),
 			) {
 				Ok(status) => {
 					generic_cache.insert(hashes[&file].clone());
@@ -200,7 +200,7 @@ impl Generic
 					Some(
 						diff_paths(
 							absolute_path,
-							&(self.environment).project_directory,
+							&self.environment.project_directory,
 						)?
 						.to_str()?
 						.to_string(),
@@ -230,7 +230,7 @@ impl Generic
 		self.system.execute(
 			linker
 				.args(&linker_args)
-				.current_dir(&(self.environment).project_directory),
+				.current_dir(&self.environment.project_directory),
 		)?;
 
 		self.ui.remove_bar(spinner);
@@ -245,10 +245,10 @@ impl Generic
 		project: &Project,
 	) -> anyhow::Result<()>
 	{
-		let obj_dir: PathBuf = (self.environment)
+		let obj_dir: PathBuf = self.environment
 			.numake_directory
 			.join(format!("obj/{}", project.name));
-		let out_dir: PathBuf = (self.environment)
+		let out_dir: PathBuf = self.environment
 			.numake_directory
 			.join(format!("out/{}", project.name));
 

--- a/src/lib/compilers/mingw.rs
+++ b/src/lib/compilers/mingw.rs
@@ -7,7 +7,7 @@ use std::{
 	path::PathBuf,
 	process::Command,
 };
-
+use std::path::Path;
 use mlua::{
 	prelude::LuaValue,
 	FromLua,
@@ -28,9 +28,8 @@ use crate::lib::{
 	},
 	runtime::system::System,
 	ui::UI,
-	util::cache::Cache,
+	util::build_cache::BuildCache,
 };
-use crate::lib::util::build_cache::BuildCache;
 
 #[derive(Clone)]
 pub struct MinGW
@@ -72,7 +71,8 @@ impl MinGW
 		 * We cache the hashes of files that have been previously compiled
 		 * to figure out whether we should compile them again.
 		 */
-		let mut mingw_cache: HashSet<String> = self.cache.read_set("mingw_cache")?;
+		let mut mingw_cache: HashSet<String> =
+			self.cache.read_set("mingw_cache")?;
 
 		/*
 		 * Hash the contents of every source file once
@@ -265,16 +265,30 @@ impl MinGW
 	fn linking_step(
 		&mut self,
 		project: &Project,
-		out_dir: &PathBuf,
-		mingw: &String,
+		out_dir: &Path,
+		mingw: &str,
 		output: &String,
-		o_files: &mut Vec<String>,
+		o_files: Vec<String>,
 	) -> anyhow::Result<()>
 	{
+		let mut relative_o_files = o_files
+			.iter()
+			.filter_map(|absolute_path| {
+				Some(
+					diff_paths(
+						absolute_path,
+						&(self.environment).project_directory,
+					)?
+					.to_str()?
+					.to_string(),
+				)
+			})
+			.collect();
+
 		let spinner = self.ui.create_spinner("Linking...");
 		match project.project_type {
 			ProjectType::StaticLibrary => {
-				let mut linker = Command::new(mingw.clone() + "ar");
+				let mut linker = Command::new(mingw.to_string() + "ar");
 				let mut linker_args = Vec::from([
 					"rcs".to_string(),
 					format!(
@@ -284,7 +298,7 @@ impl MinGW
 					),
 				]);
 
-				linker_args.append(o_files);
+				linker_args.append(&mut relative_o_files);
 
 				for def_file in
 					project.source_files.get(&SourceFileType::ModuleDefinition)
@@ -301,7 +315,7 @@ impl MinGW
 
 			_ => {
 				let mut linker = Command::new(
-					mingw.clone()
+					mingw.to_string()
 						+ match project.language {
 							ProjectLanguage::C => "gcc",
 							ProjectLanguage::CPP => "g++",
@@ -309,7 +323,7 @@ impl MinGW
 				);
 				let mut linker_args = Vec::new();
 
-				linker_args.append(o_files);
+				linker_args.append(&mut relative_o_files);
 
 				for def_file in
 					project.source_files.get(&SourceFileType::ModuleDefinition)
@@ -394,7 +408,7 @@ impl MinGW
 			&out_dir,
 			&mingw,
 			&project.output.clone().unwrap_or("out".to_string()),
-			&mut o_files,
+			o_files,
 		)?;
 
 		project.copy_assets(&self.environment.project_directory, &out_dir)?;

--- a/src/lib/compilers/mingw.rs
+++ b/src/lib/compilers/mingw.rs
@@ -60,8 +60,8 @@ impl MinGW
 	fn compile_step(
 		&mut self,
 		project: &Project,
-		obj_dir: &PathBuf,
-		mingw: &String,
+		obj_dir: &Path,
+		mingw: &str,
 		o_files: &mut Vec<String>,
 	) -> anyhow::Result<()>
 	{
@@ -125,7 +125,7 @@ impl MinGW
 		// COMPILATION STEP
 		for file in source_files.clone() {
 			let o_file = obj_dir.join(
-				diff_paths(&file, &(self.environment).project_directory)
+				diff_paths(&file, &self.environment.project_directory)
 					.unwrap()
 					.to_str()
 					.unwrap()
@@ -147,7 +147,7 @@ impl MinGW
 				"Compiling... ".to_string() + file.to_str().unwrap(),
 			);
 			let mut compiler = Command::new(
-				mingw.clone()
+				mingw.to_string()
 					+ match project.language {
 						ProjectLanguage::C => "gcc",
 						ProjectLanguage::CPP => "g++",
@@ -176,7 +176,7 @@ impl MinGW
 			match self.system.execute(
 				compiler
 					.args(&compiler_args)
-					.current_dir(&(self.environment).project_directory),
+					.current_dir(&self.environment.project_directory),
 			) {
 				Ok(status) => {
 					mingw_cache.insert(hashes[&file].clone());
@@ -197,8 +197,8 @@ impl MinGW
 	fn resource_step(
 		&mut self,
 		project: &Project,
-		mingw: &String,
-		res_dir: &PathBuf,
+		mingw: &str,
+		res_dir: &Path,
 		o_files: &mut Vec<String>,
 	) -> anyhow::Result<()>
 	{
@@ -214,12 +214,12 @@ impl MinGW
 				"Compiling Resources... ".to_string()
 					+ resource_file.to_str().unwrap(),
 			);
-			let mut resource_compiler = Command::new(mingw.clone() + "windres");
+			let mut resource_compiler = Command::new(mingw.to_string() + "windres");
 
 			let coff_file = res_dir.join(
 				diff_paths(
 					&resource_file,
-					&(self.environment).project_directory,
+					&self.environment.project_directory,
 				)
 				.unwrap()
 				.to_str()
@@ -251,7 +251,7 @@ impl MinGW
 			self.system.execute(
 				resource_compiler
 					.args(&res_compiler_args)
-					.current_dir(&(self.environment).project_directory),
+					.current_dir(&self.environment.project_directory),
 			)?;
 
 			o_files.push(coff_file.to_str().unwrap().to_string());
@@ -277,7 +277,7 @@ impl MinGW
 				Some(
 					diff_paths(
 						absolute_path,
-						&(self.environment).project_directory,
+						&self.environment.project_directory,
 					)?
 					.to_str()?
 					.to_string(),
@@ -309,7 +309,7 @@ impl MinGW
 				self.system.execute(
 					linker
 						.args(&linker_args)
-						.current_dir(&(self.environment).project_directory),
+						.current_dir(&self.environment.project_directory),
 				)?;
 			}
 
@@ -356,7 +356,7 @@ impl MinGW
 				self.system.execute(
 					linker
 						.args(&linker_args)
-						.current_dir(&(self.environment).project_directory),
+						.current_dir(&self.environment.project_directory),
 				)?;
 			}
 		}
@@ -371,14 +371,14 @@ impl MinGW
 		project: &Project,
 	) -> anyhow::Result<()>
 	{
-		let obj_dir: PathBuf = (self.environment)
+		let obj_dir: PathBuf = self.environment
 			.numake_directory
 			.join(format!("obj/{}", &project.name));
-		let out_dir: PathBuf = (self.environment)
+		let out_dir: PathBuf = self.environment
 			.numake_directory
 			.join(format!("out/{}", &project.name));
 
-		let res_dir: PathBuf = (self.environment)
+		let res_dir: PathBuf = self.environment
 			.numake_directory
 			.join(format!("res/{}", &project.name));
 

--- a/src/lib/compilers/msvc.rs
+++ b/src/lib/compilers/msvc.rs
@@ -9,7 +9,7 @@ use std::{
 	path::PathBuf,
 	process::Command,
 };
-
+use std::path::Path;
 use anyhow::anyhow;
 use mlua::{
 	prelude::LuaValue,
@@ -38,6 +38,7 @@ use crate::lib::{
 		error::NuMakeError::VcNotFound,
 	},
 };
+use crate::lib::util::error::NuMakeError::MsvcWindowsOnly;
 
 #[derive(Clone)]
 pub struct MSVC
@@ -73,7 +74,7 @@ impl MSVC
 	) -> anyhow::Result<HashMap<String, String>>
 	{
 		let vswhere_path =
-			(self.environment).numake_directory.join("vswhere.exe");
+			self.environment.numake_directory.join("vswhere.exe");
 		if !vswhere_path.exists() {
 			download_vswhere(&vswhere_path)?;
 		}
@@ -148,7 +149,7 @@ impl MSVC
 		&mut self,
 		project: &Project,
 		working_directory: &PathBuf,
-		obj_dir: &PathBuf,
+		obj_dir: &Path,
 		msvc_env: &HashMap<String, String>,
 		o_files: &mut Vec<String>,
 	) -> anyhow::Result<()>
@@ -217,7 +218,7 @@ impl MSVC
 		// COMPILATION STEP
 		for file in source_files.clone() {
 			let o_file = obj_dir.join(
-				diff_paths(&file, &(self.environment).numake_directory)
+				diff_paths(&file, &self.environment.numake_directory)
 					.unwrap()
 					.to_str()
 					.unwrap()
@@ -283,8 +284,8 @@ impl MSVC
 		&mut self,
 		project: &Project,
 		working_directory: &PathBuf,
-		obj_dir: &PathBuf,
-		res_dir: &PathBuf,
+		obj_dir: &Path,
+		res_dir: &Path,
 		msvc_env: &HashMap<String, String>,
 		o_files: &mut Vec<String>,
 	) -> anyhow::Result<()>
@@ -306,7 +307,7 @@ impl MSVC
 			let res_file = res_dir.join(
 				diff_paths(
 					&resource_file,
-					&(self.environment).numake_directory,
+					&self.environment.numake_directory,
 				)
 				.unwrap()
 				.to_str()
@@ -347,7 +348,7 @@ impl MSVC
 			let rbj_file = obj_dir.join(
 				diff_paths(
 					&resource_file,
-					&(self.environment).numake_directory,
+					&self.environment.numake_directory,
 				)
 				.unwrap()
 				.to_str()
@@ -388,7 +389,7 @@ impl MSVC
 		project: &Project,
 		output: &String,
 		working_directory: &PathBuf,
-		out_dir: &PathBuf,
+		out_dir: &Path,
 		msvc_env: &HashMap<String, String>,
 		o_files: Vec<String>,
 	) -> anyhow::Result<()>

--- a/src/lib/data/project.rs
+++ b/src/lib/data/project.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use mlua::{FromLua, Lua, MetaMethod, UserData, UserDataFields, UserDataMethods, Value};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use mlua::prelude::LuaValue;
 use crate::lib::data::project_language::ProjectLanguage;
 

--- a/src/lib/init/mod.rs
+++ b/src/lib/init/mod.rs
@@ -4,7 +4,6 @@ use crate::lib::data::environment::Environment;
 use crate::lib::runtime::Runtime;
 use crate::lib::ui::{format, UI};
 use clap::Parser;
-use mlua::prelude::LuaResult;
 use std::env;
 use std::process::ExitCode;
 

--- a/src/lib/util/build_cache.rs
+++ b/src/lib/util/build_cache.rs
@@ -1,10 +1,7 @@
 use crate::lib::data::environment::Environment;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
-use std::fs::File;
-use std::io::Write;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 
 #[derive(Default, Debug, Clone)]
 pub struct BuildCache {


### PR DESCRIPTION
When providing object files to the linker, we now use relative paths in order to avoid OS error 206.